### PR TITLE
Add Product column to Variant index table

### DIFF
--- a/src/elements/Variant.php
+++ b/src/elements/Variant.php
@@ -726,6 +726,7 @@ class Variant extends Purchasable
     {
         return [
             'title' => Craft::t('commerce', 'Title'),
+            'product' => Craft::t('commerce', 'Product'),
             'sku' => Craft::t('commerce', 'SKU'),
             'price' => Craft::t('commerce', 'Price'),
             'width' => Craft::t('commerce', 'Width ({unit})', ['unit' => Plugin::getInstance()->getSettings()->dimensionUnits]),
@@ -745,6 +746,7 @@ class Variant extends Purchasable
         $attributes = [];
 
         $attributes[] = 'title';
+        $attributes[] = 'product';
         $attributes[] = 'sku';
         $attributes[] = 'price';
 
@@ -781,6 +783,10 @@ class Variant extends Purchasable
             case 'sku':
                 {
                     return $this->sku;
+                }
+            case 'product':
+                {
+                    return $this->product->title;
                 }
             case 'price':
                 {


### PR DESCRIPTION
Fixes #333 by adding a `product` column to `defineTableAttributes`, `defineDefaultTableAttributes`, and a clause in the `case` statement within `getTableAttributeHtml`.

This does not make any change to how elements are rendered in the CP—this seems to be governed primarily by one function in the View component.

I may open an issue in the `cms` repo suggesting this be broken out a bit, such that we could more easily override just the contents of an element chiclet, but not have to reconstruct it entirely (or parse the HTML in a second hook, make modifications, and pack back into a string).